### PR TITLE
Add BigQuery definitions

### DIFF
--- a/terraform/schema/test_partitioning_table.json
+++ b/terraform/schema/test_partitioning_table.json
@@ -1,0 +1,20 @@
+[
+    {
+      "name": "name",
+      "type": "STRING",
+      "mode": "NULLABLE",
+      "description": "名称"
+    },
+    {
+      "name": "description",
+      "type": "STRING",
+      "mode": "NULLABLE",
+      "description": "説明"
+    },
+    {
+      "name": "day",
+      "type": "DATE",
+      "mode": "NULLABLE",
+      "description": "日付パーティションで使用するカラム"
+    }
+]


### PR DESCRIPTION
Terraform定義にBigQueryのデータセットとテーブルを追加。
テーブルのスキーマは直書きとスキーマ定義ファイル読み込みの両方で記述。